### PR TITLE
Enhancement/disable album commments likes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,4 +9,4 @@ good-names=e,ex,id,r,i,j
 max-line-length=200
 
 # Maximum number of lines in a module
-max-module-lines=2000
+max-module-lines=2500

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ This script is mostly based on the following original script: [REDVM/immich_auto
                             If set, the script tries to access all passed root paths and recursively search for .albumprops files in all contained folders. These properties will be used to set custom options on an per-album level. Check the readme for a complete documentation. (default: False)
       --api-timeout API_TIMEOUT
                             Timeout when requesting Immich API in seconds (default: 20)
+      --comments-and-likes-enabled
+                            Pass this argument to enable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled (default: False)
+      --comments-and-likes-disabled
+                            Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-enabled (default: False)
     ```
 
 __Plain example without optional arguments:__
@@ -169,6 +173,7 @@ The environment variables are analoguous to the script's command line arguments.
 | FIND_ARCHIVED_ASSETS     | no | By default, the script only finds assets that are not archived in Immich. Set this option make the script discover assets that are already archived. If -A/--find-assets-in-albums is set as well, both options apply. (default: `False`)<br>Refer to [Automatic Archiving](#automatic-archiving). |
 | READ_ALBUM_PROPERTIES     | no | Set to `True` to enable discovery of `.albumprops` files in root paths, allowing to set different album properties for differnt albums. (default: `False`)<br>Refer to [Setting Album-Fine Properties](#setting-album-fine-properties). |
 | API_TIMEOUT         | no | Timeout when requesting Immich API in seconds (default: `20`) |
+| COMMENTS_AND_LIKES  | no | Set to `1` to explicitly enable Comments & Likes functionality for all albums this script adds assets to, set to `0` to disable. If not set, this setting is left alone by the script. |
 
 #### Run the container with Docker
 

--- a/docker/immich_auto_album.sh
+++ b/docker/immich_auto_album.sh
@@ -149,5 +149,11 @@ if [ ! -z "$API_TIMEOUT" ]; then
     args="--api-timeout \"$API_TIMEOUT\" $args"
 fi
 
+if [ "$COMMENTS_AND_LIKES" == "1" ]; then
+    args="--comments-and-likes-enabled $args"
+elif [ "$COMMENTS_AND_LIKES" == "0" ]; then
+    args="--comments-and-likes-disabled $args"
+fi
+
 BASEDIR=$(dirname "$0")
 echo $args | xargs python3 -u $BASEDIR/immich_auto_album.py

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -1691,8 +1691,10 @@ parser.add_argument("--read-album-properties", action="store_true",
                     help="""If set, the script tries to access all passed root paths and recursively search for .albumprops files in all contained folders.
                             These properties will be used to set custom options on an per-album level. Check the readme for a complete documentation.""")
 parser.add_argument("--api-timeout",  default=REQUEST_TIMEOUT_DEFAULT, type=int, help="Timeout when requesting Immich API in seconds")
-parser.add_argument("--comments-and-likes-enabled", action="store_true", help="Pass this argument to enable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
-parser.add_argument("--comments-and-likes-disabled", action="store_true", help="Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-enabled")
+parser.add_argument("--comments-and-likes-enabled", action="store_true",
+                    help="Pass this argument to enable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
+parser.add_argument("--comments-and-likes-disabled", action="store_true",
+                    help="Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-enabled")
 
 
 args = vars(parser.parse_args())

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -1692,7 +1692,7 @@ parser.add_argument("--read-album-properties", action="store_true",
                             These properties will be used to set custom options on an per-album level. Check the readme for a complete documentation.""")
 parser.add_argument("--api-timeout",  default=REQUEST_TIMEOUT_DEFAULT, type=int, help="Timeout when requesting Immich API in seconds")
 parser.add_argument("--comments-and-likes-enabled", action="store_true", help="Pass this argument to enable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
-parser.add_argument("--comments-and-likes-disabled", action="store_true", help="Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
+parser.add_argument("--comments-and-likes-disabled", action="store_true", help="Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-enabled")
 
 
 args = vars(parser.parse_args())

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -1520,6 +1520,12 @@ def set_album_properties_in_model(album_model_to_update: AlbumModel):
     if album_order:
         album_model_to_update.sort_order = album_order
 
+    # Comments and Likes
+    if comments_and_likes_enabled:
+        album_model_to_update.comments_and_likes_enabled = True
+    elif comments_and_likes_disabled:
+        album_model_to_update.comments_and_likes_enabled = False
+
 def build_album_list(asset_list : list[dict], root_path_list : list[str], album_props_templates: dict) -> dict:
     """
     Builds a list of album models, enriched with assets assigned to each album.
@@ -1685,6 +1691,8 @@ parser.add_argument("--read-album-properties", action="store_true",
                     help="""If set, the script tries to access all passed root paths and recursively search for .albumprops files in all contained folders.
                             These properties will be used to set custom options on an per-album level. Check the readme for a complete documentation.""")
 parser.add_argument("--api-timeout",  default=REQUEST_TIMEOUT_DEFAULT, type=int, help="Timeout when requesting Immich API in seconds")
+parser.add_argument("--comments-and-likes-enabled", action="store_true", help="Pass this argument to enable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
+parser.add_argument("--comments-and-likes-disabled", action="store_true", help="Pass this argument to disable comment and like functionality in all albums this script adds assets to. Cannot be used together with --comments-and-likes-disabled")
 
 
 args = vars(parser.parse_args())
@@ -1720,6 +1728,11 @@ archive = args["archive"]
 find_archived_assets = args["find_archived_assets"]
 read_album_properties = args["read_album_properties"]
 api_timeout = args["api_timeout"]
+comments_and_likes_enabled = args["comments_and_likes_enabled"]
+comments_and_likes_disabled = args["comments_and_likes_disabled"]
+if comments_and_likes_disabled and comments_and_likes_enabled:
+    logging.fatal("Arguments --comments-and-likes-enabled and --comments-and-likes-disabled cannot be used together! Choose one!")
+    sys.exit(1)
 
 # Override unattended if we're running in destructive mode
 if mode != SCRIPT_MODE_CREATE:
@@ -1753,6 +1766,8 @@ logging.debug("archive = %s", archive)
 logging.debug("find_archived_assets = %s", find_archived_assets)
 logging.debug("read_album_properties = %s", read_album_properties)
 logging.debug("api_timeout = %s", api_timeout)
+logging.debug("comments_and_likes_enabled = %s", comments_and_likes_enabled)
+logging.debug("comments_and_likes_disabled = %s", comments_and_likes_disabled)
 
 # Verify album levels
 if is_integer(album_levels) and album_levels == 0:


### PR DESCRIPTION
Added options `--comments-and-likes-disabled` and `--comments-and-likes-enabled` / env variable `COMMENTS_AND_LIKES` (values `0` or `1`) to explicitly disable or enable comments and likes in albums