### PR TITLE
Fix: Negative Album Level Ranges for Docker

### DIFF
--- a/docker/immich_auto_album.sh
+++ b/docker/immich_auto_album.sh
@@ -90,7 +90,7 @@ if [ ! -z "$additional_root_paths" ]; then
 fi
 
 if [ ! -z "$ALBUM_LEVELS" ]; then
-    args="--album-levels=$ALBUM_LEVELS $args"
+    args="--album-levels=\"$ALBUM_LEVELS\" $args"
 fi
 
 if [ ! -z "$ALBUM_SEPARATOR" ]; then


### PR DESCRIPTION
Fixed passing `--album-levels` argument to support negative album level ranges for Docker