### PR TITLE
Draft new --dont-merge-albums option

### DIFF
--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -847,8 +847,8 @@ def fetch_albums(track_assent_paths=True) -> dict:
     check_api_response(r)
     albums = r.json()
 
-    # in case we care don't want to track the original paths of the assets
-    if track_assent_paths:
+    # in case don't want to merge folders, we need to track the original paths of the assets
+    if not merge_folder:
         for album in albums:
             album_detail = fetch_album_info(album['id'])
 
@@ -1679,7 +1679,7 @@ def build_album_list(asset_list : list[dict], root_path_list : list[str], album_
         del path_chunks[-1]
         album_name = create_album_name(path_chunks, album_level_separator, album_name_post_regex)
         if len(album_name) > 0:
-            logging.info("Asset '%s' -> Album '%s'", asset_to_add['originalPath'], album_name)
+            logging.debug("Asset '%s' -> Album '%s'", asset_to_add['originalPath'], album_name)
             
             # Check if album properties exist for this album
             album_props_template = album_props_templates.get(album_name)
@@ -2076,13 +2076,13 @@ for album in albums_to_create:
     if not album.id:
         album.id = create_album(album.get_final_name())
         created_albums.append(album)
-        logging.info('Album %s added!', album.get_final_name())
+        logging.info('Album %s added %s', album.get_final_name(),album.id)
 
-    logging.info("Adding assets to album %s", album.get_final_name())
+    logging.info("Adding assets to album %s %s", album.get_final_name(), album.id)
     assets_added = add_assets_to_album(album.id, album.get_asset_uuids())
     if len(assets_added) > 0:
         asset_uuids_added += assets_added
-        logging.info("%d new assets added to %s", len(assets_added), album.get_final_name())
+        logging.info("%d new assets added to %s %s", len(assets_added), album.get_final_name(), album.id)
 
     # Update album properties depending on mode or if newly created
     if update_album_props_mode > 0 or (album in created_albums):


### PR DESCRIPTION
Hi 

As shortly disussed in [here](https://github.com/Salvoxia/immich-folder-album-creator/issues/115#issuecomment-2699035496) I made an attempt how _not_ to merge albums with the same name.  Its a bit random hacking for preview and I hope it does only fit my use cases  - maybe I'm wrong and you see a better approach :-) I see some controversial overlap with the album merge option but I never had a case for this. 

Assume this:
```
/mnt/piclib/
└──  2022/
   └── 1224 Spring Holiday
└──  2023/
   └── 1224 Spring Holiday
└──  2024/
   └── 1224 Spring Holiday
```
I use the regex feature to remove the digits but it should not matter. same applies if we would just have steady  'Kitten Convention' Folder in every year.

In the current default behavior, all Spring images will be merged into one album as they have share the same name. However, in my world, I would like to have a dedicated album for each year (as other people to share and so on)

It works like this:
- in each run, it compares the new unassigned assets for any different root path, if so they will be assigned to individual AlbumModel object
- it fetches the album list as before but it also ensembles a unique list of root paths of each album.
- it assigns the new assets to an existing album if album Name is the same AND the root path is the same as the existing assets. If not a new album will be created. 

Example: 
 - Spring Holiday 2024 is complete new album
 - Spring Holiday 2023 and 2022 a new photo was added: 

So its going like this: 
`immich_auto_album.py /mnt/piclib/ https://photos.xxx.com/api <key> -a 2 -s "" --album-name-post-regex \^\[\\d\]+ --dont-merge-folder`

Log: 
```
20 photos found
3 new/modified albums identified
 - Album Spring Holiday, Assets 17, Paths ['/mnt/piclib/2024/1224 Spring Holiday']
 - Album Spring Holiday, Assets 2, Paths ['/mnt/piclib/2023/1224 Spring Holiday']
 - Album Spring Holiday, Assets 1, Paths ['/mnt/piclib/2022/1224 Spring Holiday']
Press enter to create these albums, Ctrl+C to abort

Listing existing albums on immich
145 existing albums identified
Create / Append to Albums
Album Spring Holiday added 7cf02600-ef0f-4a57-bb8c-a33f6d927689
Adding assets to album Spring Holiday 7cf02600-ef0f-4a57-bb8c-a33f6d927689
17 new assets added to Spring Holiday 7cf02600-ef0f-4a57-bb8c-a33f6d927689
Adding assets to album Spring Holiday c04d3485-f42a-428a-b4a2-035c495d1dfc
2 new assets added to Spring Holiday c04d3485-f42a-428a-b4a2-035c495d1dfc
Adding assets to album Spring Holiday af9bf2a0-8e05-4f10-81c1-91d7567e1e63
1 new assets added to Spring Holiday af9bf2a0-8e05-4f10-81c1-91d7567e1e63
1 albums created
Done!
```
caveats:

- I did some major tweaks and optimization, not on purpose - please don't get me wrong
- maybe I overlooked something
- I wasn't able to test all use cases
- currently the album lists will be cached in a yaml file
  - for debugging
  - to store the unique lists of paths as albumPaths
  - as it takes a bit too long to fetch (?) -  (independent of preparing the albumPaths list)
  - to be discussed how and if to implement this
 - i suggest a `.albumprops ` option to re-enable those kind of catch-all albums as `--dont-merge-albums` avoid this globally. 
 - The logging above is a bit stupid, therefore I added the id. 
 - I almost killed myself with the negation of wording of variables/flags.
 -  I tried to remain current default behavior without breaking changes. 
 

let me know what you think. 

