### PR TITLE
Use tini to allow gracefull shutdown of the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY immich_auto_album.py requirements.txt docker/immich_auto_album.sh docker/se
 ARG TARGETPLATFORM
 # gcc and musl-dev are required for building requirements for regex python module
 RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then apk add gcc musl-dev; fi \
+    && apk add tini \
     && pip install --no-cache-dir -r /script/requirements.txt \
     && chmod +x /script/setup_cron.sh /script/immich_auto_album.sh \
     && rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/* \
@@ -12,4 +13,4 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then apk add gcc musl-dev; fi \
 
 ENV IS_DOCKER=1
 WORKDIR /script
-CMD ["sh", "-c", "/script/setup_cron.sh && crond -f"]
+CMD ["tini", "sh", "-c", "/script/setup_cron.sh && crond -f"]


### PR DESCRIPTION
Running `docker stop immich-folder-album-creator` takes 10 seconds to complete.
This is probably because the SIGTERM signal isn't sent to the all the processes running inside the container. After 10 seconds docker does a SIGKILL to finally stop the container.
Tini (a small init clone) handles this process for us and a docker stop now takes < 1s.