### PR TITLE
feat: Support new `visibility` option / Fix Asset Archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,20 @@ By combining `--find-archived-assets`/`FIND_ARCHIVED_ASSETS=true` with `--visibi
 >[!WARNING]  
 >If the script is used to delete albums using `--mode=CLEANUP` or `--mode=DELETE_ALL` with the `--archive` option set, the script will not respect [album-fine properties](#setting-album-fine-properties) for visibility but only the global option passed when running it in that mode! That way you can decide what visibility to set for assets after their albums have been deleted.
 
+### Locked Folder Considerations
+When setting `--visibility`/`VISIBILITY` to `locked`, the script will move all discovered assets to the Locked Folder, removing them from any albums they might already be part of. The affected assets are determined by the following options/environment variables:
+  - `--find-archived-assets`/`FIND_ARCHIVED_ASSETS`
+  - `--find-assets-in-albums`/`FIND_ASSETS_IN_ALBUMS`
+  - `--ignore`/`IGNORE`
+  - `--path-filter`/`PATH_FILTER`
+
+> [!CAUTION]  
+> When running with `--find-assets-in-albums`/`FIND_ASSETS_IN_ALBUMS` and `--visibility`/`VISIBILITY` set to `locked`, the script will move all assets for matching albums to the locked folder, leaving empty albums behind.
+When also running with `--sync-mode`/`SYNC_MODE` set to `1` or `2`, those empty albums will be deleted after that as well!
+
+Removing assets from the locked folder and making it available to the script again must be done using the Immich User Interface.
+
+
 ## Dealing with External Library Changes
 
 Due to their nature, external libraries may be changed by the user without Immich having any say in it.  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a python script designed to automatically create albums in [Immich](http
 This is useful for automatically creating and populating albums for external libraries.
 Using the provided docker image, the script can simply be added to the Immich compose stack and run along the rest of Immich's containers.
 
-__Current compatibility:__ Immich v1.106.1 - v1.132.x
+__Current compatibility:__ Immich v1.106.1 - v1.133.x
 
 ### Disclaimer
 This script is mostly based on the following original script: [REDVM/immich_auto_album.py](https://gist.github.com/REDVM/d8b3830b2802db881f5b59033cf35702)
@@ -50,7 +50,7 @@ This script is mostly based on the following original script: [REDVM/immich_auto
     - [Property Precedence](#property-precedence)
   - [Mass Updating Album Properties](#mass-updating-album-properties)
     - [Examples:](#examples)
-  - [Automatic Archiving](#automatic-archiving)
+  - [Asset Visibility & Locked Folder](#asset-visibility--locked-folder)
   - [Dealing with External Library Changes](#dealing-with-external-library-changes)
     - [`docker-compose` example passing the API key as environment variable](#docker-compose-example-passing-the-api-key-as-environment-variable)
     - [`docker-compose` example using a secrets file for the API key](#docker-compose-example-using-a-secrets-file-for-the-api-key)
@@ -128,11 +128,13 @@ options:
   --set-album-thumbnail {first,last,random,random-all,random-filtered}
                         Set first/last/random image as thumbnail for newly created albums or albums assets have been added to. If set to random-filtered, thumbnails are shuffled for all albums whose assets would not be filtered out or
                         ignored by the ignore or path-filter options, even if no assets were added during the run. If set to random-all, the thumbnails for ALL albums will be shuffled on every run. (default: None)
-  -v, --archive         Set this option to automatically archive all assets that were newly added to albums. If this option is set in combination with --mode = CLEANUP or DELETE_ALL, archived images of deleted albums will be unarchived.
-                        Archiving hides the assets from Immich's timeline. (default: False)
+  -v, --archive         DEPRECATED. Use --visibility=archive instead! This option will be removed in the future! Set this option to automatically archive all assets that were newly added to albums. If this option is set in combination with --mode = CLEANUP or DELETE_ALL, archived images of
+                        deleted albums will be unarchived. Archiving hides the assets from Immich's timeline. (default: False)
+  --visibility {archive,hidden,locked,timeline}
+                        Set this option to automatically set the visibility of all assets that are discovered by the script and assigned to albums. Exception for value 'locked': Assets will not be added to any albums, but to the 'locked' folder only. Also applies if -m/--mode is set to
+                        CLEAN_UP or DELETE_ALL; then it affects all assets in the deleted albums. Always overrides -v/--archive. (default: None)
   --find-archived-assets
-                        By default, the script only finds assets that are not archived in Immich. Set this option to make the script discover assets that are already archived. If -A/--find-assets-in-albums is set as well, both options
-                        apply. (default: False)
+                        By default, the script only finds assets with visibility set to 'timeline' (which is the default). Set this option to make the script discover assets with visibility 'archive' as well. If -A/--find-assets-in-albums is set as well, both options apply. (default: False)
   --read-album-properties
                         If set, the script tries to access all passed root paths and recursively search for .albumprops files in all contained folders. These properties will be used to set custom options on an per-album level. Check the
                         readme for a complete documentation. (default: False)
@@ -200,8 +202,9 @@ The environment variables are analogous to the script's command line arguments.
 | `FIND_ASSETS_IN_ALBUMS`      | no         | By default, the script only finds assets that are not assigned to any album yet. Set this option to make the script discover assets that are already part of an album and handle them as usual. If --find-archived-assets is set as well, both options apply. (default: `False`)<br>Refer to [Assets in Multiple Albums](#assets-in-multiple-albums). |
 | `PATH_FILTER`                | no         | A colon `:` separated list of literals or glob-style patterns to filter assets before album name creation. (default: ``)<br>Refer to [Filtering](#filtering). |
 | `SET_ALBUM_THUMBNAIL`        | no         | Set first/last/random image as thumbnail (based on image creation timestamp) for newly created albums or albums assets have been added to.<br> Allowed values: `first`,`last`,`random`,`random-filtered`,`random-all`<br>If set to `random-filtered`, thumbnails are shuffled for all albums whose assets would not be filtered out or ignored by the `IGNORE` or `PATH_FILTER` options, even if no assets were added during the run. If set to random-all, the thumbnails for ALL albums will be shuffled on every run. (default: `None`)<br>Refer to [Setting Album Thumbnails](#setting-album-thumbnails). |
-| `ARCHIVE`                    | no         | Set this option to automatically archive all assets that were newly added to albums.<br>If this option is set in combination with `MODE` = `CLEANUP` or `DELETE_ALL`, archived images of deleted albums will be unarchived.<br>Archiving hides the assets from Immich's timeline. (default: `False`)<br>Refer to [Automatic Archiving](#automatic-archiving). |
-| `FIND_ARCHIVED_ASSETS`       | no         | By default, the script only finds assets that are not archived in Immich. Set this option make the script discover assets that are already archived. If -A/--find-assets-in-albums is set as well, both options apply. (default: `False`)<br>Refer to [Automatic Archiving](#automatic-archiving). |
+| `ARCHIVE`                    | no         | __DEPRECATED! Use `VISIBILITY` instead! This option will be removed in the future!__<br>Set this option to automatically archive all assets that were newly added to albums.<br>If this option is set in combination with `MODE` = `CLEANUP` or `DELETE_ALL`, archived images of deleted albums will be unarchived.<br>Archiving hides the assets from Immich's timeline. (default: `False`)<br>Refer to [Asset Visibility & Locked Folder](#asset-visibility-locked-folder). |
+| `VISIBILITY`                 | no         | Set this option to automatically set the visibility of all assets that are discovered by the script and assigned to albums.<br>Exception for value 'locked': Assets will not be added to any albums, but to the 'locked' folder only.<br>Also applies if `MODE` is set to CLEAN_UP or DELETE_ALL; then it affects all assets in the deleted albums.<br>Always overrides `ARCHIVE`. (default: `None`)<br>Refer to [Asset Visibility & Locked Folder](#asset-visibility-locked-folder). |
+| `FIND_ARCHIVED_ASSETS`       | no         | By default, the script only finds assets with visibility set to 'timeline' (which is the default). Set this option to make the script discover assets with visibility 'archive' as well. If -A/--find-assets-in-albums is set as well, both options apply. (default: `False`)<br>Refer to [Asset Visibility & Locked Folder](#asset-visibility--locked-folder). |
 | `READ_ALBUM_PROPERTIES`      | no         | Set to `True` to enable discovery of `.albumprops` files in root paths, allowing to set different album properties for different albums. (default: `False`)<br>Refer to [Setting Album-Fine Properties](#setting-album-fine-properties). |
 | `API_TIMEOUT`                | no         | Timeout when requesting Immich API in seconds (default: `20`) |
 | `COMMENTS_AND_LIKES`         | no         | Set to `1` to explicitly enable Comments & Likes functionality for all albums this script adds assets to, set to `0` to disable. If not set, this setting is left alone by the script. |
@@ -685,8 +688,8 @@ share_with:
 thumbnail_setting: "first"
 # Sort order in album, valid values: asc, desc
 sort_oder: "desc"
-# Flag indicating whether to archive images added to this album, valid values: true, false
-archive: true
+# Set the visibility of assets that are getting added to that album, valid values: archive, hidden, locked, timeline
+visibility: 'timeline'
 # Flag indicating whether assets in this albums can be commented on and liked
 comments_and_likes_enabled: false
 ```
@@ -714,6 +717,13 @@ share_with:
     role: editor
 ```
 If the script is called with `--share-with "Mom"` and `--archive`, the album created from the folder the file above resides in will only be shared with user `Dad` using `editor` permissions, and assets will be archived. All other albums will be shared with user `Mom` (using `viewer` permissions, as defined by default) and assets will be archived.
+
+### Example: Always add files in a specific folder to Immich Locked Folder
+
+In order to always add files incoming to a specific external library folder to Immich's Locked Folder, add the following `.albumprops` file to that folder:
+```yaml
+visibility: 'locked'
+```
 
 ## Mass Updating Album Properties
 
@@ -763,17 +773,24 @@ By applying `--path-filter` and/or `--ignore` options, it is possible to get a m
     ```
 
 
-## Automatic Archiving
+## Asset Visibility & Locked Folder
 
-In Immich, 'archiving' an image means to hide it from the main timeline.  
-This script is capable of automatically archiving images it added to albums during the run to hide them from the timeline. To achieve this, run the script with option `--archive` or Docker environment variable `ARCHIVE=true`.  
+In Immich, may be 'archived' meaning they are hidden from the main timeline and only show up in their respective albums and the 'Archive' in the sidebar menu. Immich v1.133.0 also introduced the concept of a locked folder. The user must enter a PIN code to access the contents of that locked folder. Assets that are moved to the locked folder cannot be part of any albums and naturally are not displayed in the timeline.
 
+This script supports both concepts with the option/environment variable `--visibility`/`VISIBILITY`. Allowed values are:
+  - `archive`: Assets are archived after getting added to an album
+  - `locked`: No albums get created, but all discovered assets after filtering are moved to the locked folder
+  - `timeline`: All assets are shown in the timeline after getting added to an album
+
+Visibility may be on an per-album basis using [Album Properties](#setting-album-fine-properties).
 >[!IMPORTANT]  
 >Archiving images has the side effect that they are no longer detected by the script with default options. This means that if an album that was created with the `--archive` option set is deleted from the Immich user interface, the script will no longer find the images even though they are no longer assigned to an album.  
 To make the script find also archived images, run the script with the option `--find-archived-assets` or Docker environment variable `FIND_ARCHIVED_ASSETS=true`.
 
+By combining `--find-archived-assets`/`FIND_ARCHIVED_ASSETS=true` with `--visibility timeline`/`VISIBILITY timeline`, archived assets can be 'un-archived'.
+
 >[!WARNING]  
->If the script is used to delete albums using `--mode=CLEANUP` or `--mode=DELETE_ALL` with the `--archive` option set, the script will automatically unarchive all assets of deleted albums to revert them to their prior state. If you manually archived selected assets in albums, this will be reverted!
+>If the script is used to delete albums using `--mode=CLEANUP` or `--mode=DELETE_ALL` with the `--archive` option set, the script will not respect [album-fine properties](#setting-album-fine-properties) for visibility but only the global option passed when running it in that mode! That way you can decide what visibility to set for assets after their albums have been deleted.
 
 ## Dealing with External Library Changes
 

--- a/docker/immich_auto_album.sh
+++ b/docker/immich_auto_album.sh
@@ -161,8 +161,13 @@ if [ ! -z "$SET_ALBUM_THUMBNAIL" ]; then
     args="--set-album-thumbnail \"$SET_ALBUM_THUMBNAIL\" $args"
 fi
 
+# Deprecated, will be removed in future release
 if [ ! -z "$ARCHIVE" ]; then
     args="--archive $args"
+fi
+
+if [ ! -z "$VISIBILITY" ]; then
+    args="--visibility=\"$VISIBILITY\" $args"
 fi
 
 if [ ! -z "$READ_ALBUM_PROPERTIES" ]; then

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -67,7 +67,7 @@ class AlbumModel:
     ALBUM_MERGE_MODE_OVERRIDE = 3
     # List of class attribute names that are relevant for album properties handling
     # This list is used for album model merging and validation
-    ALBUM_PROPERTIES_VARIABLES = ['override_name', 'description', 'share_with', 'thumbnail_setting', 'sort_order', 'archive', 'comments_and_likes_enabled']
+    ALBUM_PROPERTIES_VARIABLES = ['override_name', 'description', 'share_with', 'thumbnail_setting', 'sort_order', 'archive', 'visibility', 'comments_and_likes_enabled']
 
     def __init__(self, name : str):
         # The album ID, set after it was created
@@ -87,7 +87,10 @@ class AlbumModel:
         # Sorting order for this album, 'asc' or 'desc'
         self.sort_order = None
         # Boolean indicating whether assets in this album should be archived after adding
+        # Deprecated, use visibility = archive instead!
         self.archive = None
+        # String indicating asset visibility, allowed values: archive, hidden, locked, timeline
+        self.visibility = None
         # Boolean indicating whether assets in this albums can be commented on and liked
         self.comments_and_likes_enabled = None
 
@@ -238,6 +241,12 @@ class AlbumModel:
                     if album_prop_name in album_properties:
                         album_props_template_vars[album_prop_name] = album_properties[album_prop_name]
 
+                # Backward compatibility, remove when archive is removed:
+                if album_props_template.archive is not None:
+                    logging.warning("Found deprecated property archive in %s! This will be removed in the future, use visibility: archive instead!", album_properties_file_path)
+                    if album_props_template.visibility == None:
+                        album_props_template.visibility = 'archive'
+                #  End backward compatibility
                 return album_props_template
 
         return None
@@ -709,7 +718,7 @@ def fetch_server_version() -> dict:
     return server_version
 
 
-def fetch_assets(is_not_in_album: bool, find_archived: bool) -> list:
+def fetch_assets(is_not_in_album: bool, visibility_options: list[str]) -> list:
     """
     Fetches assets from the Immich API.
 
@@ -722,15 +731,21 @@ def fetch_assets(is_not_in_album: bool, find_archived: bool) -> list:
             Flag indicating whether to fetch only assets that are not part
             of an album or not. If set to False, will find images in albums and 
             not part of albums
-        find_archived : bool
-            Flag indicating whether to only fetch assets that are archived. If set to False,
-            will find archived and unarchived images
+        visibility_options : list[str]
+            A list of visibility options to find and return assets with
     Returns
     ---------
         An array of asset objects
     """
-
-    return fetch_assets_with_options({'isNotInAlbum': is_not_in_album, 'withArchived': find_archived})
+    if version['major'] == 1 and version ['minor'] < 133:
+        return fetch_assets_with_options({'isNotInAlbum': is_not_in_album, 'withArchived': 'archive' in visibility_options})
+    else:
+        asset_list = fetch_assets_with_options({'isNotInAlbum': is_not_in_album})
+        for visiblity_option in visibility_options:
+            # Do not fetch agin for 'timeline', that's the default!
+            if visiblity_option != 'timeline':
+                asset_list += fetch_assets_with_options({'isNotInAlbum': is_not_in_album, 'visibility': visiblity_option})
+        return asset_list
 
 def check_for_and_remove_live_photo_video_components(asset_list: list[dict], is_not_in_album: bool, find_archived: bool) -> list[dict]:
     """
@@ -765,7 +780,11 @@ def check_for_and_remove_live_photo_video_components(asset_list: list[dict], is_
     # If either is not True, we need to fetch all assets
     if is_not_in_album or not find_archived:
         logging.debug("Fetching all assets for live photo video component check")
-        full_asset_list = fetch_assets_with_options({'isNotInAlbum': False, 'withArchived': True})
+        if version['major'] == 1 and version ['minor'] < 133:
+            full_asset_list = fetch_assets_with_options({'isNotInAlbum': False, 'withArchived': True})
+        else:
+            full_asset_list = fetch_assets_with_options({'isNotInAlbum': False})
+            full_asset_list += fetch_assets_with_options({'isNotInAlbum': False, 'visibility': 'archive'})
     else:
         full_asset_list = asset_list
 
@@ -1433,28 +1452,38 @@ def update_album_properties(album_to_update: AlbumModel):
         response = requests.patch(root_url+api_endpoint, json=data, **requests_kwargs, timeout=api_timeout)
         check_api_response(response)
 
-def set_assets_archived(asset_ids_to_archive: list[str], is_archived: bool):
+def set_assets_visibility(asset_ids_for_visibility: list[str], visibility: str):
     """
-    (Un-)Archives the assets identified by the passed list of UUIDs.
+    Sets the visibility of assets identified by the passed list of UUIDs.
 
     Parameters
     ----------
-        asset_ids_to_archive : list
-            A list of asset IDs to archive
-        isArchived : bool
-            Flag indicating whether to archive or unarchive the passed assets
+        asset_ids_for_visibility : list
+            A list of asset IDs to set visibility for
+        visibility : str
+            The visibility to set
    
     Raises
     ----------
         Exception if the API call fails
     """
     api_endpoint = 'assets'
-
-    data = {
-        "ids": asset_ids_to_archive,
-        "isArchived": is_archived
-    }
-
+    data = dict()
+    data["ids"] = asset_ids_for_visibility
+    # Remove when minimum supported version is >= 133
+    if version['major'] == 1 and version ['minor'] < 133:
+        if visibility is not None and visibility not in ['archive', 'timeline']:
+            # Warnings have been logged earlier, silently abort
+            return
+        else:
+            is_archived = True
+            if visibility == 'timeline':
+                is_archived = False
+            data["isArchived"] = is_archived
+    # Up-to-date Immich Server versions
+    else:
+        data["visibility"] = visibility
+    
     r = requests.put(root_url+api_endpoint, json=data, **requests_kwargs, timeout=api_timeout)
     check_api_response(r)
 
@@ -1483,16 +1512,16 @@ def check_api_response(response: requests.Response):
             logging.error("API response did not contain a payload")
     response.raise_for_status()
 
-def delete_all_albums(unarchive_assets: bool, force_delete: bool):
+def delete_all_albums(assets_visibility: str, force_delete: bool):
     """
     Deletes all albums in Immich if force_delete is True. Otherwise lists all albums
     that would be deleted.
-    If unarchived_assets is set to true, all archived assets in deleted albums
-    will be unarchived.
+    If assets_visibility is set, all assets in deleted albums
+    will be set to that visibility.
 
     Parameters
     ----------
-        unarchive_assets : bool
+        assets_visibility : str
             Flag indicating whether to unarchive archived assets
         force_delete : bool
             Flag indicating whether to actually delete albums (True) or only to
@@ -1524,14 +1553,14 @@ def delete_all_albums(unarchive_assets: bool, force_delete: bool):
              # If the archived flag is set it means we need to unarchived all images of deleted albums;
             # In order to do so, we need to fetch all assets of the album we're going to delete
             assets_in_deleted_album = []
-            if unarchive_assets:
+            if assets_visibility is not None:
                 album_to_delete_info = fetch_album_info(album_to_delete['id'])
                 assets_in_deleted_album = album_to_delete_info['assets']
             logging.info("Deleted album %s", album_to_delete['albumName'])
             deleted_album_count += 1
-            if len(assets_in_deleted_album) > 0 and unarchive_assets:
-                set_assets_archived([asset['id'] for asset in assets_in_deleted_album], False)
-                logging.info("Unarchived %d assets", len(assets_in_deleted_album))
+            if len(assets_in_deleted_album) > 0 and assets_visibility is not None:
+                set_assets_visibility([asset['id'] for asset in assets_in_deleted_album], assets_visibility)
+                logging.info("Set visibility for %d assets to %s", len(assets_in_deleted_album), assets_visibility)
     logging.info("Deleted %d/%d albums", deleted_album_count, len(all_albums))
 
 def cleanup_albums(albums_to_delete: list[AlbumModel], force_delete: bool):
@@ -1573,16 +1602,18 @@ def cleanup_albums(albums_to_delete: list[AlbumModel], force_delete: bool):
         # If the archived flag is set it means we need to unarchived all images of deleted albums;
         # In order to do so, we need to fetch all assets of the album we're going to delete
         assets_in_album = []
-        if album_to_delete.archive:
+        # For cleanup, we only respect the global visibility flag to be able to either do not change
+        # visibility at all, or to override whatever might be set in .ablumprops and revert to something else
+        if visibility is not None:
             album_to_delete_info = fetch_album_info(album_to_delete.id)
             assets_in_album = album_to_delete_info['assets']
         if delete_album({'id': album_to_delete.id, 'albumName': album_to_delete.get_final_name()}):
             logging.info("Deleted album %s", album_to_delete.get_final_name())
             cpt += 1
             # Archive flag is set, so we need to unarchive assets
-            if album_to_delete.archive and len(assets_in_album) > 0:
-                set_assets_archived([asset['id'] for asset in assets_in_album], False)
-                logging.info("Unarchived %d assets", len(assets_in_album))
+            if visibility is not None and len(assets_in_album) > 0:
+                set_assets_visibility([asset['id'] for asset in assets_in_album], visibility)
+                logging.info("Set visibility for %d assets to %s", len(assets_in_album), visibility)
     return cpt
 
 
@@ -1615,8 +1646,8 @@ def set_album_properties_in_model(album_model_to_update: AlbumModel):
         album_model_to_update.thumbnail_setting = set_album_thumbnail
 
     # Archive setting
-    if archive:
-        album_model_to_update.archive = archive
+    if visibility is not None:
+        album_model_to_update.visibility = visibility
 
     # Sort Order
     if album_order:
@@ -1789,13 +1820,21 @@ parser.add_argument("--set-album-thumbnail", choices=ALBUM_THUMBNAIL_SETTINGS_GL
                             If set to """+ALBUM_THUMBNAIL_RANDOM_FILTERED+""", thumbnails are shuffled for all albums whose assets would not be
                             filtered out or ignored by the ignore or path-filter options, even if no assets were added during the run.
                             If set to """+ALBUM_THUMBNAIL_RANDOM_ALL+""", the thumbnails for ALL albums will be shuffled on every run.""")
+# Backward compatibility, remove when archive is removed
 parser.add_argument("-v", "--archive", action="store_true",
-                    help="""Set this option to automatically archive all assets that were newly added to albums.
+                    help="""DEPRECATED. Use --visibility=archive instead! This option will be removed in the future!
+                            Set this option to automatically archive all assets that were newly added to albums.
                             If this option is set in combination with --mode = CLEANUP or DELETE_ALL, archived images of deleted albums will be unarchived.
                             Archiving hides the assets from Immich's timeline.""")
+# End Backward compaibility 
+parser.add_argument("--visibility", choices=['archive', 'hidden', 'locked', 'timeline'],
+                    help="""Set this option to automatically set the visibility of all assets that are discovered by the script and assigned to albums.
+                            Exception for value 'locked': Assets will not be added to any albums, but to the 'locked' folder only.
+                            Also applies if -m/--mode is set to CLEAN_UP or DELETE_ALL; then it affects all assets in the deleted albums.
+                            Always overrides -v/--archive.""")
 parser.add_argument("--find-archived-assets", action="store_true",
-                    help="""By default, the script only finds assets that are not archived in Immich.
-                            Set this option to make the script discover assets that are already archived.
+                    help="""By default, the script only finds assets with visibility set to 'timeline' (which is the default).
+                            Set this option to make the script discover assets with visibility 'archive' as well.
                             If -A/--find-assets-in-albums is set as well, both options apply.""")
 parser.add_argument("--read-album-properties", action="store_true",
                     help="""If set, the script tries to access all passed root paths and recursively search for .albumprops files in all contained folders.
@@ -1844,6 +1883,7 @@ find_assets_in_albums = args["find_assets_in_albums"]
 path_filter = args["path_filter"]
 set_album_thumbnail = args["set_album_thumbnail"]
 archive = args["archive"]
+visibility = args["visibility"]
 find_archived_assets = args["find_archived_assets"]
 read_album_properties = args["read_album_properties"]
 api_timeout = args["api_timeout"]
@@ -1854,10 +1894,16 @@ if comments_and_likes_disabled and comments_and_likes_enabled:
     sys.exit(1)
 update_album_props_mode = args["update_album_props_mode"]
 
-# Override unattended if we're running in destructive mode
 if mode != SCRIPT_MODE_CREATE:
+    # Override unattended if we're running in destructive mode
     # pylint: disable=C0103
     unattended = False
+
+# Backward compatibility, remove when archive is removed
+if visibility == None and archive:
+    visibility = 'archive'
+    logging.warning('-v/--archive is DEPRECATED! Use --visibility=archive instead! This option will be removed in the future!')
+# End Backward compaibility 
 
 is_docker = os.environ.get(ENV_IS_DOCKER, False)
 
@@ -1883,7 +1929,10 @@ logging.debug("sync_mode = %d", sync_mode)
 logging.debug("find_assets_in_albums = %s", find_assets_in_albums)
 logging.debug("path_filter = %s", path_filter)
 logging.debug("set_album_thumbnail = %s", set_album_thumbnail)
+# Backward compatibility, remove when archive is removed
 logging.debug("archive = %s", archive)
+# End Backward compaibility 
+logging.debug("visibility = %s", visibility)
 logging.debug("find_archived_assets = %s", find_archived_assets)
 logging.debug("read_album_properties = %s", read_album_properties)
 logging.debug("api_timeout = %s", api_timeout)
@@ -1970,10 +2019,9 @@ if version['major'] == 1 and version ['minor'] < 106:
     logging.fatal("This script only works with Immich Server v1.106.0 and newer! Update Immich Server or use script version 0.8.1!")
     sys.exit(1)
 
-
 # Special case: Run Mode DELETE_ALL albums
 if mode == SCRIPT_MODE_DELETE_ALL:
-    delete_all_albums(archive, delete_confirm)
+    delete_all_albums(visibility, delete_confirm)
     sys.exit(0)
 
 album_properties_templates = {}
@@ -1987,9 +2035,9 @@ logging.info("Requesting all assets")
 # only request images that are not in any album if we are running in CREATE mode,
 # otherwise we need all images, even if they are part of an album
 if mode == SCRIPT_MODE_CREATE:
-    assets = fetch_assets(not find_assets_in_albums, find_archived_assets)
+    assets = fetch_assets(not find_assets_in_albums, ['archive'] if find_archived_assets else [])
 else:
-    assets = fetch_assets(False, True)
+    assets = fetch_assets(False, ['archive'])
 
 # Remove live photo video components
 assets = check_for_and_remove_live_photo_video_components(assets, not find_assets_in_albums, find_archived_assets)
@@ -2000,6 +2048,11 @@ logging.info("%d photos found", len(assets))
 logging.info("Sorting assets to corresponding albums using folder name")
 albums_to_create = build_album_list(assets, root_paths, album_properties_templates)
 albums_to_create = dict(sorted(albums_to_create.items(), key=lambda item: item[0]))
+
+if version['major'] == 1 and version ['minor'] < 133:
+    albums_with_visibility = [album_check_to_check for album_check_to_check in albums_to_create.values() if album_check_to_check.visibility is not None and album_check_to_check.visibility != 'archive']
+    if len(albums_with_visibility) > 0:
+        logging.warning("Option 'visibility' is only supported in Immich Server v1.133.x and newer! Option will be ignored!")
 
 logging.info("%d albums identified", len(albums_to_create))
 logging.info("Album list: %s", list(albums_to_create.keys()))
@@ -2044,6 +2097,13 @@ created_albums = []
 # List for gathering all asset UUIDs for later archiving
 asset_uuids_added = []
 for album in albums_to_create.values():
+    # Special case: Add assets to Locked folder
+    # Locked assets cannot be part of an album, so don't create albums in the first place
+    if(album.visibility == 'locked'):
+        set_assets_visibility(album.get_asset_uuids(), album.visibility)
+        logging.info("Added %d assets to locked folder", len(album.get_asset_uuids()))
+        continue
+    
     # Create album if inexistent:
     if not album.id:
         album.id = create_album(album.get_final_name())
@@ -2055,6 +2115,11 @@ for album in albums_to_create.values():
     if len(assets_added) > 0:
         asset_uuids_added += assets_added
         logging.info("%d new assets added to %s", len(assets_added), album.get_final_name())
+
+    # Set assets visibility
+    if(album.visibility is not None):
+        set_assets_visibility(assets_added, album.visibility)
+        logging.info("Set visibility for %d assets to %s", len(assets_added), album.visibility)
 
     # Update album properties depending on mode or if newly created
     if update_album_props_mode > 0 or (album in created_albums):
@@ -2070,11 +2135,6 @@ for album in albums_to_create.values():
         update_album_shared_state(album, True)
 
 logging.info("%d albums created", len(created_albums))
-
-# Archive assets
-if archive and len(asset_uuids_added) > 0:
-    set_assets_archived(asset_uuids_added, True)
-    logging.info("Archived %d assets", len(asset_uuids_added))
 
 # Perform album cover randomization
 if set_album_thumbnail == ALBUM_THUMBNAIL_RANDOM_ALL:


### PR DESCRIPTION
Immich Server v1.133.0 introduced a new asset property `visibility` with possible values `archive`, `hidden`, `locked` and `timeline`,
replacing the old `isArchived` property.

This PR introduces a new option/env variables `--visibility`/`VISIBILITY` to continue supporting asset archiving as well as the new Locked Folder Feature.

Deprecates `-v`/`--archive`/`ARCHIVE` option/environment variable in favor of new `--visibility`/`VISIBILITY` option/environment.
Fixes handling of archived assets.