### PR TITLE
README: Update docker-compose example to illustrate prerequisites for `.albumprops`

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ services:
     restart: unless-stopped
     volumes:
      - /path/to/secret/file:/immich_api_key.secret:ro
+     # mount needed for .albumprops to work
+     - /path/to/my/photos:/external_libs/photos
     environment:
       API_URL: http://immich_server:2283/api
       API_KEY_FILE: /immich_api_key.secret


### PR DESCRIPTION
Updated docker-compose example to include external library mount for enabling `.albumprops` feature

Addresses #164