### PR TITLE
chore: README: Remove duplicate asset.delete permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The list contains API key permissions valid for **Immich v2.1.0**.
   - `asset`
     - `asset.read`
     - `asset.delete`
-    - `asset.delete`
   - `album`
     - `album.create`
     - `album.read`


### PR DESCRIPTION
Removed duplicate `asset.delete` permission from the list of API key permissions