### PR TITLE
chore: README: Removed album.addAsset from API key permisisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The list contains API key permissions valid for **Immich v2.1.0**.
     - `album.read`
     - `album.update`
     - `album.delete`
-    - `album.addAsset`
   - `albumAsset`
     - `albumAsset.create`
   - `albumUser`


### PR DESCRIPTION
Removed `album.addAsset` from list of API key permissions, since it no longer exists and is superseded by `albumAsset.create`