### PR TITLE
fix: Fixed container start behavior (RUN_IMMEDIATELY, dry run)

### DIFF
--- a/docker/setup_cron.sh
+++ b/docker/setup_cron.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+if [ ! -z "$RUN_IMMEDIATELY" ] && { [ "$RUN_IMMEDIATELY" = "true" ] || [ "$RUN_IMMEDIATELY" = "1" ]; }; then
+    UNATTENDED=1 /script/immich_auto_album.sh > /proc/1/fd/1 2>/proc/1/fd/2 || true
+fi
 if [ ! -z "$CRON_EXPRESSION" ]; then
     CRONTAB_PATH="$CRONTAB_DIR/crontab"
     # Create and lock down crontab
@@ -11,5 +14,5 @@ if [ ! -z "$CRON_EXPRESSION" ]; then
     fi
     /usr/local/bin/supercronic -passthrough-logs -no-reap -split-logs $DEBUG_PARM $CRONTAB_PATH
 else
-    UNATTENDED=1 /script/immich_auto_album.sh > /proc/1/fd/1 2>/proc/1/fd/2 || true
+    /script/immich_auto_album.sh > /proc/1/fd/1 2>/proc/1/fd/2 || true
 fi


### PR DESCRIPTION
  - Re-added support for `RUN_IMMEDIATELY`:  Immediately performs one run, then starts supercronic
  - Running the container without `CRON_EXPRESSION` performs a dry-run
  - Running the container without without `CRON_EXPRESSION` but with `UNATTENDED=1` performs one run, creating albums