### PR TITLE
chore: README: Added asset.read to API key permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The list contains API key permissions valid for **Immich v2.1.0**.
   - `asset`
     - `asset.read`
     - `asset.delete`
+    - `asset.update`
   - `album`
     - `album.create`
     - `album.read`


### PR DESCRIPTION
Added `asset.read` to API key permissions list in the README.md, this is required for the `archive` or `locked` options of the `visibility` setting to work.

Closes #255