### PR TITLE
Throw exception for non utf-8 .albumfiles

### DIFF
--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -1118,29 +1118,34 @@ class AlbumModel:
 
         :raises YAMLError: If the provided album properties file could not be found or parsed
         """
-        with open(album_properties_file_path, 'r', encoding="utf-8") as stream:
-            album_properties = yaml.safe_load(stream)
-            if album_properties:
-                album_props_template = AlbumModel(None)
-                album_props_template_vars = vars(album_props_template)
+        try:
+            with open(album_properties_file_path, 'r', encoding="utf-8") as stream:
+                album_properties = yaml.safe_load(stream)
+        except UnicodeDecodeError:
+            logging.warning("File '%s' is not UTF-8 encoded. Please save it as UTF-8.", album_properties_file_path)
+            raise
 
-                # Parse standard album properties
-                for album_prop_name in AlbumModel.ALBUM_PROPERTIES_VARIABLES:
-                    if album_prop_name in album_properties:
-                        album_props_template_vars[album_prop_name] = album_properties[album_prop_name]
+        if album_properties:
+            album_props_template = AlbumModel(None)
+            album_props_template_vars = vars(album_props_template)
 
-                # Parse inheritance properties
-                for inheritance_prop_name in AlbumModel.ALBUM_INHERITANCE_VARIABLES:
-                    if inheritance_prop_name in album_properties:
-                        album_props_template_vars[inheritance_prop_name] = album_properties[inheritance_prop_name]
+            # Parse standard album properties
+            for album_prop_name in AlbumModel.ALBUM_PROPERTIES_VARIABLES:
+                if album_prop_name in album_properties:
+                    album_props_template_vars[album_prop_name] = album_properties[album_prop_name]
 
-                # Backward compatibility, remove when archive is removed:
-                if album_props_template.archive is not None:
-                    logging.warning("Found deprecated property archive in %s! This will be removed in the future, use visibility: archive instead!", album_properties_file_path)
-                    if album_props_template.visibility is None:
-                        album_props_template.visibility = 'archive'
-                #  End backward compatibility
-                return album_props_template
+            # Parse inheritance properties
+            for inheritance_prop_name in AlbumModel.ALBUM_INHERITANCE_VARIABLES:
+                if inheritance_prop_name in album_properties:
+                    album_props_template_vars[inheritance_prop_name] = album_properties[inheritance_prop_name]
+
+            # Backward compatibility, remove when archive is removed:
+            if album_props_template.archive is not None:
+                logging.warning("Found deprecated property archive in %s! This will be removed in the future, use visibility: archive instead!", album_properties_file_path)
+                if album_props_template.visibility is None:
+                    album_props_template.visibility = 'archive'
+            #  End backward compatibility
+            return album_props_template
 
         return None
 


### PR DESCRIPTION
Had the exact same issue as #228, and i got albums with badly encoded names.

This pull request adds error handling for non-UTF-8 encoded album properties files in the `parse_album_properties_file` function. If the file is not UTF-8 encoded, a warning is logged and the error is raised to inform the user.

Not too opinionated on the specific handling, but since the code expects utf-8 anyway, it should be enforced.