### PR TITLE
fix: unpin regex version to support Python 3.14+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 urllib3
 pyyaml
-regex==2024.11.6
+regex>=2024.11.6
 tenacity>=9.0.0,<10.0.0
 # check https://github.com/timonrieger/immichpy/blob/main/COMPATIBILITY.csv
 # for the exact version to use that supports the server version you are using


### PR DESCRIPTION
## Summary

- Loosens `regex==2024.11.6` to `regex>=2024.11.6` in `requirements.txt`
- The pinned version lacks pre-built wheels for Python 3.14, causing `pip install` to fail when C build tools are not available

## Test plan

- [x] Verified `pip install -r requirements.txt` succeeds on Python 3.14.3
- [x] Verified script runs correctly with `regex>=2026.2.28`

Fixes #275