### PR TITLE
fix: Offline Asset Removal: Remove offline assets with all visibility settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,10 +1095,10 @@ Option `1` leaves it up to the user to clear up "offline" assets by emptying the
 Option `2` will first delete all "offline" assets automatically, then do the same with any empty albums left.  
 
 > [!IMPORTANT]  
-> For Immich v1.116.0 - v1.127.x finding offline assets has been broken. Immich fixed the issue with v1.128.0.
+> If your library is on a network share or external drive that might be prone to not being available all the time, avoid using `Sync Mode = 2`.
 
 > [!IMPORTANT]  
-> If your library is on a network share or external drive that might be prone to not being available all the time, avoid using `Sync Mode = 2`.
+> Removing offline assets from the locked folder requires an API key with elevated privileges. If your API key is not elevated, a warning will be logged.
 
 > [!CAUTION]  
 > It is __not__ possible for the script to distinguish between an album that was left behind empty after Offline Asset Removal and a manually created album with no images added to it! All empty albums of that user will be deleted!

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -489,7 +489,7 @@ class ApiClient:
         for visibility_setting in AssetVisibility:
             try:
                 offline_assets += self.fetch_assets_with_options(MetadataSearchDto(is_offline=True, visibility=visibility_setting))
-            except UnauthorizedException as ex:
+            except UnauthorizedException:
                 logging.warning('Admin-level API key required to check for offline assets in locked folder, skipping...')
 
         if len(offline_assets) > 0:

--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -43,7 +43,7 @@ from immichpy.client.generated import (
     UserResponseDto,
 )
 from immichpy import AsyncClient
-from immichpy.client.generated.exceptions import ApiException
+from immichpy.client.generated.exceptions import ApiException, UnauthorizedException
 from tenacity import (
     retry_if_exception,
     retry_if_exception_type,
@@ -484,7 +484,13 @@ class ApiClient:
 
         :raises: Exception if any API call fails
         """
-        offline_assets = self.fetch_assets_with_options(MetadataSearchDto(is_offline=True))
+        offline_assets = []
+        # To find all offline assets we need to check for each possible visibility
+        for visibility_setting in AssetVisibility:
+            try:
+                offline_assets += self.fetch_assets_with_options(MetadataSearchDto(is_offline=True, visibility=visibility_setting))
+            except UnauthorizedException as ex:
+                logging.warning('Admin-level API key required to check for offline assets in locked folder, skipping...')
 
         if len(offline_assets) > 0:
             logging.info("Deleting %s offline assets", len(offline_assets))


### PR DESCRIPTION
Offline asset removal used the `"isOffline": true` metadata search option without combining it with a visibility setting.
This caused offline asset removal to only find and remove offline assets with the default visibility `timeline` and skip other settings such as `archive`.
This fix loops over all possible visibility settings when searching for offline assets before removing them.
Finding assets with `"visibility": "locked"´ requires elevated privileges and will produce a warning if the used API key has insufficient privileges.

Fixes #287