### PR TITLE
Fixed album cover randomization

### DIFF
--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -2197,10 +2197,10 @@ class FolderAlbumCreator():
                 album_model.thumbnail_setting = 'random'
                 thumbnail_asset = self.choose_thumbnail(album_model.thumbnail_setting, album_model.assets)
                 if thumbnail_asset:
-                    logging.info("Using asset %s as thumbnail for album %s", thumbnail_asset.original_path, album.get_final_name())
+                    logging.info("Using asset %s as thumbnail for album %s", thumbnail_asset.original_path, album_model.get_final_name())
                     album_model.thumbnail_asset_uuid = thumbnail_asset.id
                 else:
-                    logging.warning("Unable to determine thumbnail for setting '%s' in album %s", album.thumbnail_setting, album.get_final_name())
+                    logging.warning("Unable to determine thumbnail for setting '%s' in album %s", album_model.thumbnail_setting, album_model.get_final_name())
                 # Update album properties (which will only pick a random thumbnail and set it, no other properties are changed)
                 self.api_client.update_album_properties(album_model)
 


### PR DESCRIPTION
Hello there,
I have encountered what seems to be a bug with the album cover randomization set with `SET_ALBUM_THUMBNAIL: random-all`.
The expected behaviour would be that all album covers are updated after every run of this script. However, when running the script, I get the following log entry:
```
immich_folder_album_creator  | time="2026-06-29T18:19:06+02:00" level=info msg="Picking a new random thumbnail for all albums"
immich_folder_album_creator  | Traceback (most recent call last):
immich_folder_album_creator  |   File "/script/immich_auto_album.py", line 2379, in <module>
immich_folder_album_creator  |     folder_album_creator.run()
immich_folder_album_creator  |     ~~~~~~~~~~~~~~~~~~~~~~~~^^
immich_folder_album_creator  |   File "/script/immich_auto_album.py", line 2200, in run
immich_folder_album_creator  |     logging.info("Using asset %s as thumbnail for album %s", thumbnail_asset.original_path, album.get_final_name())
immich_folder_album_creator  |                                                                                             ^^^^^
immich_folder_album_creator  | UnboundLocalError: cannot access local variable 'album' where it is not associated with a value
```
which led to no album thumbnails being updated.
Upon code inspection, I found that this seems to be a simple copy-and-paste bug and applied the small fix present in my commit.
The code now runs as expected.
Cheers,

eutill