### PR TITLE
Normalize Unicode form when matching album names to folders

### DIFF
--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -21,6 +21,7 @@ import random
 from urllib.error import HTTPError
 import traceback
 from uuid import UUID
+import unicodedata
 import regex
 import yaml
 from aiohttp import TCPConnector, ClientSession, ClientTimeout
@@ -1938,8 +1939,9 @@ class FolderAlbumCreator():
         :returns: The ID of the requested album or None if not found
         :rtype: str
         """
+        normalized_album_name = unicodedata.normalize("NFC", album_name)
         for _ in albums_list:
-            if _.album_name == album_name:
+            if unicodedata.normalize("NFC", _.album_name) == normalized_album_name:
                 return _.id
         return None
 


### PR DESCRIPTION
## Problem

`get_album_id_by_name` matches a freshly-computed album name against existing
Immich albums with a bare string `==`:

```python
for _ in albums_list:
    if _.album_name == album_name:
        return _.id
```

Two Unicode strings can render identically and still be different byte
sequences — a precomposed character (NFC, one codepoint) vs a decomposed one
(NFD, base letter + combining accent). Exact `==` treats them as unrelated,
so anything that can introduce this difference between the folder-derived
name and whatever's already stored as the album name will cause the tool to
create a new album instead of recognizing the existing one.

## How I found this

While investigating duplicate albums in my own library, the actual root
cause turned out to be genuinely duplicate folders on disk (a historical
migration had left one NFC-encoded and one NFD-encoded copy of the same
tree) — so in my case the tool was behaving correctly given two distinct
directories. But reading `get_album_id_by_name` while diagnosing that, the
matching logic itself has no protection against this class of mismatch in
general: an album renamed via the Immich UI with an input method that
normalizes differently than the folder scan, or any other path that writes
an album name in a different Unicode form, would hit the same failure mode.

## Fix

Normalize both sides to NFC before comparing. This is strictly more
permissive than the current check and has no effect on the common case
(ASCII names, or names already consistently encoded).

## Testing

Ran against my own library (several hundred albums, many with Czech
diacritics) with `UPDATE_ALBUM_PROPS_MODE=2` and `SHARE_WITH` set, across
repeated runs — no regressions, matching behaves as before for
already-consistent names.
