### PR TITLE
Fix share_with inheritance merge bug

### DIFF
--- a/immich_auto_album.py
+++ b/immich_auto_album.py
@@ -1675,7 +1675,7 @@ class FolderAlbumCreator():
             # Merge inherited and current share_with using the special merge logic
             temp_model = AlbumModel(None)
             temp_model.share_with = inherited_share_with
-            inherited_model.share_with = inherited_model.merge_inherited_share_with(inherited_model.share_with)
+            inherited_model.share_with = inherited_model.merge_inherited_share_with(temp_model.share_with)
 
         return inherited_model
 


### PR DESCRIPTION
# Problem
`share_with` inheritance, when both the parent and child .albumprops included `share_with`, was broken. The temp_model was built and assigned but never used. The merge call was merging the child with itself, resulting in only the child's `share_with` values being used.

# Reproduction
This does not occur in cases in which only the child or only the parent defines `share_with:`; it's when they both define it.
```
/photos/.albumprops         → inherit: true, share_with: [mom viewer]
/photos/trip/.albumprops  → inherit: true, share_with: [dad viewer]
```
Expected: album shared with mom and dad. Actual: dad only.

# Changes
The correct code was already mostly there, but the wrong variable was being used for the merge (child's list was being merged with itself). A correct example can be found on lines 2093–2102 in the album-merging path.

# Testing
Verified against my existing albums which mirror the reproduction case above.